### PR TITLE
Fix "can not find handler" error in tfjs-node-doodle demo

### DIFF
--- a/tfjs-node-doodle/package.json
+++ b/tfjs-node-doodle/package.json
@@ -4,8 +4,8 @@
   "description": "Doodling with tfjs-node",
   "private": false,
   "dependencies": {
-    "@tensorflow/tfjs": "0.11.7",
-    "@tensorflow/tfjs-node": "^0.1.7",
+    "@tensorflow/tfjs": "^0.13.5",
+    "@tensorflow/tfjs-node": "^0.1.21",
     "eslint": "4.19.1"
   },
   "scripts": {


### PR DESCRIPTION
Thanks for your neat demos, these demos really help me a lot.

While I following the instruction of tfjs-node-doodle demo, I got the following error: (mac 10.14.1
node: 11.2.0)
<img width="1194" alt="2018-11-26 1 22 43" src="https://user-images.githubusercontent.com/7977100/49007331-0df1d480-f120-11e8-9347-967261f4ef76.png">

It seems that this error is caused by tfjs version not compatible with tfjs-node version declared in package.json.

In this PR, I upgrade tfjs and tfjs-node to latest version to fixed this error. 
<img width="453" alt="2018-11-26 2 21 25" src="https://user-images.githubusercontent.com/7977100/49008159-02071200-f122-11e8-9993-922ac3fcfa66.png">



